### PR TITLE
Add enable_jekyll option to prevent site reprocessing during deployment

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,4 +32,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          enable_jekyll: false  # ✅ prevents GitHub from reprocessing the site
           publish_branch: gh-pages


### PR DESCRIPTION
GitHub was trying to run my site with github-pages gem constraints.

Our Gemfile specifies a custom Jekyll version and theme (jekyll ~> 4.3.2, just-the-docs).

This tells GitHub not to default to their github-pages build constraints.