### PR TITLE
Fix logo path for asset loading

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ collections:
     output: true
 
 just_the_docs:
-  logo: "/assets/images/logo.png"
+  logo: "/fallacytag/assets/images/logo.png"
   show_sidebar: true
   collections:
     pages:


### PR DESCRIPTION
Update the logo path in the configuration to ensure correct loading of the asset.