### PR TITLE
Remove dependency installation step from Jekyll workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -18,12 +18,6 @@ jobs:
         with:
           ruby-version: '3.4'
 
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle config set path 'vendor/bundle'
-          bundle install
-
       - name: Build site with Jekyll
         run: bundle exec jekyll build
 


### PR DESCRIPTION
Eliminate the dependency installation step in the Jekyll workflow to streamline the build process.