### PR TITLE
Stop using bundle exec jekyll build because we’re not relying on a lo…

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -19,7 +19,7 @@ jobs:
           ruby-version: '3.4'
 
       - name: Build site with Jekyll
-        run: bundle exec jekyll build
+        run:  jekyll build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
…cal Gemfile anymore.