### PR TITLE
Refactor markdown headers and fix nav_order formatting

### DIFF
--- a/_pages/03-scaffolded-intelligence.md
+++ b/_pages/03-scaffolded-intelligence.md
@@ -4,6 +4,6 @@ title: 3. Scaffolded Intelligence
 nav_order: 4
 ---
 
-# 3. Scaffolded Intelligence
+## 3. Scaffolded Intelligence
 
 Coming soon…

--- a/_pages/04-introducing-fallacytag.md
+++ b/_pages/04-introducing-fallacytag.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: 4. Introducing FallacyTag
-navorder: 5
+nav_order: 5
 ---
 
-# 4. Introducing FallacyTag
+## 4. Introducing FallacyTag
 
 Coming soon…

--- a/_pages/05-modalities-and-fit.md
+++ b/_pages/05-modalities-and-fit.md
@@ -4,6 +4,6 @@ title: 5. Modalities and Fit
 nav_order: 6
 ---
 
-# 5. Modalities and Fit
+## 5. Modalities and Fit
 
 Coming soon…

--- a/_pages/06-how-it-works.md
+++ b/_pages/06-how-it-works.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: 6. How It Works
-navorder: 7
+nav_order: 7
 ---
 
-# 6. How It Works
+## 6. How It Works
 
 Coming soon…

--- a/_pages/07-feasibility.md
+++ b/_pages/07-feasibility.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: 7. Is FallacyTag Feasible?
-navorder: 8
+nav_order: 8
 ---
 
-# 7. Is FallacyTag Feasible?
+## 7. Is FallacyTag Feasible?
 
 Coming soon…

--- a/_pages/08-constraints.md
+++ b/_pages/08-constraints.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: 8. Staying Honest at the Edges
-navorder: 9
+nav_order: 9
 ---
 
-# 8. Staying Honest at the Edges
+## 8. Staying Honest at the Edges
 
 Coming soon…

--- a/_pages/09-worth-building.md
+++ b/_pages/09-worth-building.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: "9. Conditional Case - When This Is Worth Building"
-navorder: 10
+nav_order: 10
 ---
 
-# 9. Conditional Case: When This Is Worth Building
+## 9. Conditional Case: When This Is Worth Building
 
 Coming soon…

--- a/_pages/10-call-to-explore.md
+++ b/_pages/10-call-to-explore.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: 10. Call to Explore
-navorder: 11
+nav_order: 11
 ---
-# 10. Call to Explore
+## 10. Call to Explore
 
 Coming soon…

--- a/_pages/appendix-a.md
+++ b/_pages/appendix-a.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Appendix A – Veritasium Logic Check
-navorder: 12
+nav_order: 12
 ---
-# Appendix A – Veritasium Logic Check
+## Appendix A – Veritasium Logic Check
 
 Coming soon…

--- a/_pages/appendix-b.md
+++ b/_pages/appendix-b.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: Appendix B – Reddit CMV Logic Check
-navorder: 13
+nav_order: 13
 ---
 
-# Appendix B – Reddit CMV Logic Check
+## Appendix B – Reddit CMV Logic Check
 
 Coming soon…

--- a/_pages/references.md
+++ b/_pages/references.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: References
-navorder: 14
+nav_order: 14
 ---
 
-# References
+## References
 
 Coming soon…

--- a/index.md
+++ b/index.md
@@ -1,12 +1,32 @@
 ---
 layout: default
-title: About
+title: Hello
 nav_order: 1
 ---
 
-# FallacyTag: Surfacing Argument Structure in Public Discourse
+## FallacyTag: Surfacing Argument Structure in Public Discourse
 
-Welcome. Choose a section from the sidebar.
+A lightweight reasoning-feedback layer for flawed logic in the wild.
 
 📬 [Subscribe on Substack](https://coherentdrift.substack.com)  
-📄 Full paper: Coming soon – browse sections in the sidebar.
+📄 Full paper: Sections released at least once a week — [browse what's online](/fallacytag/)
+
+---
+
+FallacyTag is an experiment in restoring **structure to public reasoning**.  
+It explores how we might give flawed arguments the same visibility as typos—  
+*not to shame*, but to support reflection, clarity, and better conversations.
+
+This site hosts the live draft of the FallacyTag paper.  
+Sections are being released incrementally. So far, the following are available:
+
+- ✅ Section 0: Abstract  
+- ✅ Section 1: Introduction  
+- ✅ Section 2: What’s Avoided at Scale  
+- ⏳ Sections 3–10: Coming soon  
+
+Check the sidebar for what’s currently available, or follow the project on Substack for updates.
+
+If you're a builder, educator, or curious skeptic—welcome.
+
+---


### PR DESCRIPTION
Standardize header levels and correct the navigation order formatting across multiple markdown files for consistency and clarity.